### PR TITLE
Removed 'renderer' as needed parameter in all cases.

### DIFF
--- a/src/modules/debug/debug_ui.cs
+++ b/src/modules/debug/debug_ui.cs
@@ -9,7 +9,7 @@ namespace Fjord.Modules.Debug {
         public static void draw_fps() {
             V2 tmp_res = game.resolution;
             game.set_render_resolution(game.renderer, 1920, 1080);
-            draw.text(game.renderer, 10, 10, "default", 42, "FPS: " + game.get_fps().ToString());
+            draw.text(10, 10, "default", 42, "FPS: " + game.get_fps().ToString());
             game.set_render_resolution(game.renderer, (int)tmp_res.x, (int)tmp_res.y);
         }
     }

--- a/src/modules/game/component.cs
+++ b/src/modules/game/component.cs
@@ -62,7 +62,7 @@ namespace Fjord.Modules.Game {
             origin.y = (int)texture_origin.y;
 
             if(visible)
-                draw.texture_ext(game.renderer, texture, (int)parent.get_component<Transform>().position.x, (int)parent.get_component<Transform>().position.y, parent.get_component<Transform>().rotation, parent.get_component<Transform>().scale.x, parent.get_component<Transform>().scale.y, true, draw_origin.CENTER, texture_flip);
+                draw.texture_ext(texture, (int)parent.get_component<Transform>().position.x, (int)parent.get_component<Transform>().position.y, parent.get_component<Transform>().rotation, parent.get_component<Transform>().scale.x, parent.get_component<Transform>().scale.y, true, draw_origin.CENTER, texture_flip);
         }
     }
 }

--- a/src/modules/game/tilemap.cs
+++ b/src/modules/game/tilemap.cs
@@ -62,7 +62,7 @@ namespace Fjord.Modules.Game {
             string ass = game.asset_pack;
             game.set_asset_pack(asset_pack);
 
-            atlas = texture_handler.load_texture(atlas_str, game.renderer);
+            atlas = texture_handler.load_texture(atlas_str);
             
             game.set_asset_pack(ass);
         }
@@ -112,7 +112,7 @@ namespace Fjord.Modules.Game {
 
                         // SDL.SDL_RenderCopyEx(game.renderer, atlas, ref src_rect, ref dest_rect, 0, ref point, SDL.SDL_RendererFlip.SDL_FLIP_NONE);
 
-                        draw.texture_atlas(game.renderer, atlas, (int)map[tilemap_funcs.create_pos(i, j)].x * 8, (int)map[tilemap_funcs.create_pos(i, j)].y * 8, 8, 8, (int)(position.x + (i * grid_w) * zoom),  (int)(position.y + (j * grid_h) * zoom), 0, (int)(grid_w * zoom), (int)(grid_h * zoom), new SDL_Point(0, 0), true);
+                        draw.texture_atlas(atlas, (int)map[tilemap_funcs.create_pos(i, j)].x * 8, (int)map[tilemap_funcs.create_pos(i, j)].y * 8, 8, 8, (int)(position.x + (i * grid_w) * zoom),  (int)(position.y + (j * grid_h) * zoom), 0, (int)(grid_w * zoom), (int)(grid_h * zoom), new SDL_Point(0, 0), true);
                         //draw.texture_ext(game.renderer, textures_intptr[map[i, j] - 1], (int)(position.x + (i * grid_w) * zoom), (int)(position.y + (j * grid_h) * zoom), 0, (int)(grid_w * zoom), (int)(grid_h * zoom), point, true);
                     }
                 }

--- a/src/modules/graphics/draw.cs
+++ b/src/modules/graphics/draw.cs
@@ -50,7 +50,7 @@ namespace Fjord.Modules.Graphics {
             return new V2(x_, y_);
         }
 
-        public static void rect(IntPtr renderer, SDL_Rect rect, byte r, byte g, byte b, byte a, bool fill, bool relative = false) {
+        public static void rect(SDL_Rect rect, byte r, byte g, byte b, byte a, bool fill, bool relative = false) {
             SDL_Color old_color;
             rect.x -= (relative ? (int)camera.camera_position.x : 0);
             rect.y -= (relative ? (int)camera.camera_position.y : 0);
@@ -67,7 +67,7 @@ namespace Fjord.Modules.Graphics {
             SDL_SetRenderDrawColor(game.renderer, old_color.r, old_color.g, old_color.b, old_color.a);
         }
 
-        public static void round_rect(IntPtr renderer, SDL_Rect rect, byte r, byte g, byte b, byte a, int border_radius, bool fill) {
+        public static void round_rect(SDL_Rect rect, byte r, byte g, byte b, byte a, int border_radius, bool fill) {
             SDL_Color old_color;
             SDL_GetRenderDrawColor(game.renderer, out old_color.r, out old_color.g, out old_color.b, out old_color.a);
             SDL_SetRenderDrawColor(game.renderer, r, g, b, a);
@@ -96,10 +96,10 @@ namespace Fjord.Modules.Graphics {
                 SDL_RenderFillRect(game.renderer, ref vertical1);
                 SDL_RenderFillRect(game.renderer, ref vertical2);
 
-                draw.quarter(game.renderer, rect.x + border_radius, rect.y + border_radius, border_radius, r, g, b, a, 1);
-                draw.quarter(game.renderer, rect.x + rect.w - border_radius - 1, rect.y + border_radius, border_radius, r, g, b, a, 2);
-                draw.quarter(game.renderer, rect.x + rect.w - border_radius - 1, rect.y + rect.h - border_radius - 1, border_radius, r, g, b, a, 3);
-                draw.quarter(game.renderer, rect.x + border_radius, rect.y + rect.h - border_radius - 1, border_radius, r, g, b, a, 4);
+                draw.quarter(rect.x + border_radius, rect.y + border_radius, border_radius, r, g, b, a, 1);
+                draw.quarter(rect.x + rect.w - border_radius - 1, rect.y + border_radius, border_radius, r, g, b, a, 2);
+                draw.quarter(rect.x + rect.w - border_radius - 1, rect.y + rect.h - border_radius - 1, border_radius, r, g, b, a, 3);
+                draw.quarter(rect.x + border_radius, rect.y + rect.h - border_radius - 1, border_radius, r, g, b, a, 4);
 
             } else {
                 SDL_RenderDrawRect(game.renderer, ref rect);
@@ -108,10 +108,10 @@ namespace Fjord.Modules.Graphics {
             SDL_SetRenderDrawColor(game.renderer, old_color.r, old_color.g, old_color.b, old_color.a);
         }
 
-        public static void circle(IntPtr renderer, int x, int y, int radius, byte r, byte g, byte b, byte a){
+        public static void circle(int x, int y, int radius, byte r, byte g, byte b, byte a){
             SDL_Color oldcolor;
             SDL_GetRenderDrawColor(game.renderer, out oldcolor.r, out oldcolor.g, out oldcolor.b, out oldcolor.a);
-            SDL_SetRenderDrawColor(renderer, r, g, b, a);
+            SDL_SetRenderDrawColor(game.renderer, r, g, b, a);
             for (int w = 0; w < radius * 2; w++)
             {
                 for (int h = 0; h < radius * 2; h++)
@@ -120,17 +120,17 @@ namespace Fjord.Modules.Graphics {
                     int dy = radius - h; // vertical offset
                     if ((dx*dx + dy*dy) <= (radius * radius))
                     {
-                        SDL_RenderDrawPoint(renderer, x + dx, y + dy);
+                        SDL_RenderDrawPoint(game.renderer, x + dx, y + dy);
                     }
                 }
             }
-            SDL_SetRenderDrawColor(renderer, oldcolor.r, oldcolor.g, oldcolor.b, oldcolor.a);
+            SDL_SetRenderDrawColor(game.renderer, oldcolor.r, oldcolor.g, oldcolor.b, oldcolor.a);
         }  
 
-        public static void quarter(IntPtr renderer, int x, int y, int radius, byte r, byte g, byte b, byte a, int side){
+        public static void quarter(int x, int y, int radius, byte r, byte g, byte b, byte a, int side){
             SDL_Color oldcolor;
             SDL_GetRenderDrawColor(game.renderer, out oldcolor.r, out oldcolor.g, out oldcolor.b, out oldcolor.a);
-            SDL_SetRenderDrawColor(renderer, r, g, b, a);
+            SDL_SetRenderDrawColor(game.renderer, r, g, b, a);
             for (int w = 0; w < radius * 2; w++)
             {
                 for (int h = 0; h < radius * 2; h++)
@@ -140,24 +140,24 @@ namespace Fjord.Modules.Graphics {
                     if ((dx*dx + dy*dy) <= (radius * radius))
                     {
                         if(w > radius && h > radius && side == 1) {
-                            SDL_RenderDrawPoint(renderer, x + dx, y + dy);
+                            SDL_RenderDrawPoint(game.renderer, x + dx, y + dy);
                         }
                         else if(w < radius && h > radius && side == 2) {
-                            SDL_RenderDrawPoint(renderer, x + dx, y + dy);
+                            SDL_RenderDrawPoint(game.renderer, x + dx, y + dy);
                         }
                         else if(w < radius && h < radius && side == 3) {
-                            SDL_RenderDrawPoint(renderer, x + dx, y + dy);
+                            SDL_RenderDrawPoint(game.renderer, x + dx, y + dy);
                         }
                         else if(w > radius && h < radius && side == 4) {
-                            SDL_RenderDrawPoint(renderer, x + dx, y + dy);
+                            SDL_RenderDrawPoint(game.renderer, x + dx, y + dy);
                         }
                     }
                 }
             }
-            SDL_SetRenderDrawColor(renderer, oldcolor.r, oldcolor.g, oldcolor.b, oldcolor.a);
+            SDL_SetRenderDrawColor(game.renderer, oldcolor.r, oldcolor.g, oldcolor.b, oldcolor.a);
         } 
     
-        public static void texture(IntPtr renderer, IntPtr texture, int x, int y, double angle, bool relative=false, draw_origin Origin=draw_origin.TOP_LEFT, flip_type flip=flip_type.none) {
+        public static void texture(IntPtr texture, int x, int y, double angle, bool relative=false, draw_origin Origin=draw_origin.TOP_LEFT, flip_type flip=flip_type.none) {
             SDL_Point size;
             uint format;
             int access;
@@ -190,10 +190,10 @@ namespace Fjord.Modules.Graphics {
                 flip_sdl = SDL_RendererFlip.SDL_FLIP_VERTICAL;
             }
 
-            SDL_RenderCopyEx(renderer, texture, ref src, ref dest, angle, ref center, flip_sdl);
+            SDL_RenderCopyEx(game.renderer, texture, ref src, ref dest, angle, ref center, flip_sdl);
         }
 
-        public static void texture_ext(IntPtr renderer, IntPtr texture, int x, int y, double angle, double x_scale, double y_scale, bool relative=false, draw_origin origin_=draw_origin.TOP_LEFT, flip_type flip=flip_type.none) {
+        public static void texture_ext(IntPtr texture, int x, int y, double angle, double x_scale, double y_scale, bool relative=false, draw_origin origin_=draw_origin.TOP_LEFT, flip_type flip=flip_type.none) {
             uint f;
             int a, w, h;
             SDL_Point origin = new SDL_Point(0, 0);
@@ -217,10 +217,10 @@ namespace Fjord.Modules.Graphics {
                 flip_sdl = SDL_RendererFlip.SDL_FLIP_VERTICAL;
             }
 
-            SDL_RenderCopyEx(renderer, texture, ref src, ref dest, 0, ref origin, flip_sdl);
+            SDL_RenderCopyEx(game.renderer, texture, ref src, ref dest, 0, ref origin, flip_sdl);
         }
 
-        public static void texture_atlas(IntPtr renderer, IntPtr texture_atlas, int atlas_x, int atlas_y, int atlas_w, int atlas_h, int x, int y, double angle, int dest_w, int dest_h, SDL_Point origin_, bool relative=false, draw_origin Origin=draw_origin.TOP_LEFT, flip_type flip=flip_type.none) {
+        public static void texture_atlas(IntPtr texture_atlas, int atlas_x, int atlas_y, int atlas_w, int atlas_h, int x, int y, double angle, int dest_w, int dest_h, SDL_Point origin_, bool relative=false, draw_origin Origin=draw_origin.TOP_LEFT, flip_type flip=flip_type.none) {
 
             SDL_Rect src_rect = new SDL_Rect(atlas_x, atlas_y, atlas_w, atlas_h);
             SDL_Rect dest_rect = new SDL_Rect(x - (relative ? (int)camera.camera_position.x : 0), y - (relative ? (int)camera.camera_position.y : 0), dest_w, dest_h);
@@ -235,10 +235,10 @@ namespace Fjord.Modules.Graphics {
                 flip_sdl = SDL_RendererFlip.SDL_FLIP_VERTICAL;
             }
 
-            SDL_RenderCopyEx(renderer, texture_atlas, ref src_rect, ref dest_rect, angle, ref origin_, flip_sdl);
+            SDL_RenderCopyEx(game.renderer, texture_atlas, ref src_rect, ref dest_rect, angle, ref origin_, flip_sdl);
         }
 
-        public static void line(IntPtr renderer, int x, int y, int x2, int y2, byte r, byte g, byte b, byte a) {
+        public static void line(int x, int y, int x2, int y2, byte r, byte g, byte b, byte a) {
             SDL_Color old_color;
             SDL_GetRenderDrawColor(game.renderer, out old_color.r, out old_color.g, out old_color.b, out old_color.a);
             SDL_SetRenderDrawColor(game.renderer, r, g, b, a);
@@ -250,7 +250,7 @@ namespace Fjord.Modules.Graphics {
 
         // TODO: Make this work ffs
 
-        public static void thick_line(IntPtr renderer, int x, int y, int x2, int y2, int width, byte r, byte g, byte b, byte a) {
+        public static void thick_line(int x, int y, int x2, int y2, int width, byte r, byte g, byte b, byte a) {
             SDL_Color old_color;
             SDL_GetRenderDrawColor(game.renderer, out old_color.r, out old_color.g, out old_color.b, out old_color.a);
             SDL_SetRenderDrawColor(game.renderer, r, g, b, a);
@@ -264,21 +264,21 @@ namespace Fjord.Modules.Graphics {
 
             IntPtr line = SDL_CreateRGBSurface(0, width, (int)Mathf.Mathf.get_hypot(new V2(x, y), new V2(x2, y2)), 32, rmask, gmask, bmask, amask);
             IntPtr texture = SDL_CreateTextureFromSurface(game.renderer, line);
-            draw.texture_ext(game.renderer, texture, x, y, Mathf.Mathf.get_dir(new V2(x, y), new V2(x2, y2)), 1, 1, false);
+            draw.texture_ext(texture, x, y, Mathf.Mathf.get_dir(new V2(x, y), new V2(x2, y2)), 1, 1, false);
 
             SDL_SetRenderDrawColor(game.renderer, old_color.r, old_color.g, old_color.b, old_color.a);            
         }
 
-        public static void text(IntPtr renderer, int x, int y, string font, int font_size, string text, byte r=255, byte g=255, byte b=255, byte a=255) {
+        public static void text(int x, int y, string font, int font_size, string text, byte r=255, byte g=255, byte b=255, byte a=255) {
             IntPtr texture; 
-            font_handler.get_texture(renderer, text, font, out texture, 0, 0, r, g, b, a);
+            font_handler.get_texture(text, font, out texture, 0, 0, r, g, b, a);
 
             SDL_Rect src;
             src.x = src.y = 0;
 
             double scale = (double)font_size / (double)font_handler.get_font_size(font);
 
-            draw.texture_ext(renderer, texture, x, y, 0, scale, scale);
+            draw.texture_ext(texture, x, y, 0, scale, scale);
         }
     }
 }

--- a/src/modules/graphics/font_handler.cs
+++ b/src/modules/graphics/font_handler.cs
@@ -34,7 +34,7 @@ namespace Fjord.Modules.Graphics
             return false;
         }
 
-        public static void get_texture(IntPtr renderer, string text, string font_id, out IntPtr texture, int x = 0, int y = 0, byte r = 255, byte g = 255, byte b = 255, byte a = 255) {
+        public static void get_texture(string text, string font_id, out IntPtr texture, int x = 0, int y = 0, byte r = 255, byte g = 255, byte b = 255, byte a = 255) {
             var key_ = hash.HashString(text + font_id);
             if(!texts.ContainsKey(key_)) {
                 IntPtr surface;
@@ -46,7 +46,7 @@ namespace Fjord.Modules.Graphics
                 textColor.a = a;    
 
                 surface = TTF_RenderText_Solid(font, text, textColor);
-                var texture_ = SDL_CreateTextureFromSurface(renderer, surface);
+                var texture_ = SDL_CreateTextureFromSurface(game.renderer, surface);
                 SDL_FreeSurface(surface);
 
                 texts.Add(key_, texture_);

--- a/src/modules/graphics/texture_handler.cs
+++ b/src/modules/graphics/texture_handler.cs
@@ -12,7 +12,7 @@ namespace Fjord.Modules.Graphics {
             SDL_FreeSurface(tmp_surface);       
         }
 
-        public static IntPtr load_texture(string file, IntPtr renderer) {
+        public static IntPtr load_texture(string file) {
             IntPtr tmp_surface = IMG_Load(game.get_resource_folder() + "/" + game.asset_pack + "/assets/images/" + file);
             IntPtr texture = default_texture;
             if(File.Exists(game.get_resource_folder() + "/" + game.asset_pack + "/assets/images/" + file)) {

--- a/src/modules/tools/tilemap_editor.cs
+++ b/src/modules/tools/tilemap_editor.cs
@@ -46,7 +46,7 @@ namespace Fjord.Game {
 
             game.set_asset_pack("MiniJam88");
             Tilemap.atlas_str = "atlas.png";
-            atlas = texture_handler.load_texture("atlas.png", game.renderer);
+            atlas = texture_handler.load_texture("atlas.png");
 
             game.set_asset_pack("general");
             font_handler.load_font("font", "FiraCode", 22);
@@ -56,7 +56,7 @@ namespace Fjord.Game {
             if(input.get_key_just_pressed(input.key_r)) {
                 if(input.get_key_pressed(input.key_lshift) && input.get_key_pressed(input.key_lctrl)) {
                     game.set_asset_pack("MiniJam88");
-                    atlas = texture_handler.load_texture("atlas.png", game.renderer);
+                    atlas = texture_handler.load_texture("atlas.png");
                 }
             }
 
@@ -217,11 +217,11 @@ namespace Fjord.Game {
                     rect.y = j * (int)(Tilemap.grid_h * zoom) + (grid_y);
                     rect.w = (int)(Tilemap.grid_w * zoom);
                     rect.h = (int)(Tilemap.grid_h * zoom);
-                    draw.rect(game.renderer, rect, 255, 255, 255, 255, false);
+                    draw.rect(rect, 255, 255, 255, 255, false);
 
-                    draw.texture_atlas(game.renderer, atlas, (int)Tilemap.map[tilemap_funcs.create_pos(i, j)].x * Tilemap.atlas_gridw, (int)Tilemap.map[tilemap_funcs.create_pos(i, j)].y * Tilemap.atlas_gridh, 8, 8, rect.x, rect.y, 0, rect.w, rect.h, new SDL_Point(0, 0), false, draw_origin.CENTER, flip_type.none);
+                    draw.texture_atlas(atlas, (int)Tilemap.map[tilemap_funcs.create_pos(i, j)].x * Tilemap.atlas_gridw, (int)Tilemap.map[tilemap_funcs.create_pos(i, j)].y * Tilemap.atlas_gridh, 8, 8, rect.x, rect.y, 0, rect.w, rect.h, new SDL_Point(0, 0), false, draw_origin.CENTER, flip_type.none);
                     if(Tilemap.collision_map[tilemap_funcs.create_pos(i, j)])
-                        draw.rect(game.renderer, rect, 255, 0, 0, 50, true, false);
+                        draw.rect(rect, 255, 0, 0, 50, true, false);
                 }
             }
 
@@ -232,16 +232,16 @@ namespace Fjord.Game {
             rect1.y = 0;
             rect1.w = 250;
             rect1.h = 1280;
-            draw.rect(game.renderer, rect1, 0, 0, 0, 200, true);
+            draw.rect(rect1, 0, 0, 0, 200, true);
 
             // Draws atlas
 
-            draw.texture_ext(game.renderer, atlas, 10, 10, 0, 230, 575, false);
+            draw.texture_ext(atlas, 10, 10, 0, 230, 575, false);
 
             if(Math.Round(mouse.x/ 58f) < 4 && Math.Round(mouse.y / 58f) < 10)
-                draw.rect(game.renderer, new SDL_Rect(10 + (int)(Math.Round((mouse.x- 29) / 58f) * 58f), 10 + (int)(Math.Round((mouse.y - 29) / 58f) * 58f), 58, 58), 0, 255, 0, 255, false);
+                draw.rect(new SDL_Rect(10 + (int)(Math.Round((mouse.x- 29) / 58f) * 58f), 10 + (int)(Math.Round((mouse.y - 29) / 58f) * 58f), 58, 58), 0, 255, 0, 255, false);
 
-            draw.rect(game.renderer, new SDL_Rect(10 + (int)selected_tile.x* 58, 10 + (int)selected_tile.y * 58, 58, 58), 119, 172, 241, 100, true);
+            draw.rect(new SDL_Rect(10 + (int)selected_tile.x* 58, 10 + (int)selected_tile.y * 58, 58, 58), 119, 172, 241, 100, true);
 
             // Draws ui
 

--- a/src/modules/ui/zgui.cs
+++ b/src/modules/ui/zgui.cs
@@ -25,21 +25,21 @@ namespace Fjord.Modules.Ui
             rect1.y = rect.y - 3;
             rect1.w = rect.w + 6;
             rect1.h = rect.h + 6;
-            draw.rect(game.renderer, rect1, o3.r, o3.g, o3.b, o3.a, false);
+            draw.rect(rect1, o3.r, o3.g, o3.b, o3.a, false);
 
             rect1.x = rect.x - 2;
             rect1.y = rect.y - 2;
             rect1.w = rect.w + 4;
             rect1.h = rect.h + 4;
-            draw.rect(game.renderer, rect1, o2.r, o2.g, o2.b, o2.a, false);
+            draw.rect(rect1, o2.r, o2.g, o2.b, o2.a, false);
 
             rect1.x = rect.x - 1;
             rect1.y = rect.y - 1;
             rect1.w = rect.w + 2;
             rect1.h = rect.h + 2;
-            draw.rect(game.renderer, rect1, o1.r, o1.g, o1.b, o1.a, false);
+            draw.rect(rect1, o1.r, o1.g, o1.b, o1.a, false);
 
-            draw.rect(game.renderer, rect, bg.r, bg.g, bg.b, bg.a, true);
+            draw.rect(rect, bg.r, bg.g, bg.b, bg.a, true);
 
             if (show_label) {
                 // render::text(x + 13, y - 5, font, string, false, color::black());
@@ -47,16 +47,16 @@ namespace Fjord.Modules.Ui
                 IntPtr texture;
                 SDL_Rect dest;
 
-                font_handler.get_texture(game.renderer, title, font, out texture, 0, 0, 0, 0, 0, 255);
-                //draw.texture_ext(game.renderer, texture, rect.x + 13, rect.y - 5, 0);
+                font_handler.get_texture(title, font, out texture, 0, 0, 0, 0, 0, 255);
+                //draw.texture_ext(texture, rect.x + 13, rect.y - 5, 0);
                 dest.x = rect.x + 13;
                 dest.y = rect.y - 5;
                 dest.w = rect1.w;
                 dest.h = rect1.h;
                 SDL_RenderCopy(game.renderer, texture, ref rect1, ref dest);
 
-                font_handler.get_texture(game.renderer, title, font, out texture);
-                //draw.texture_ext(game.renderer, texture, rect.x + 11, rect.y - 7, 0);
+                font_handler.get_texture(title, font, out texture);
+                //draw.texture_ext(texture, rect.x + 11, rect.y - 7, 0);
                 dest.x = rect.x + 11;
                 dest.y = rect.y - 7;
                 dest.w = rect1.w;
@@ -81,9 +81,9 @@ namespace Fjord.Modules.Ui
             rect.w = width;
             rect.h = 6;
 
-            draw.rect(game.renderer, rect, 36, 36, 36, 255, true);
+            draw.rect(rect, 36, 36, 36, 255, true);
             rect.w = (int)(value * ((float)width / (float)max_value)); 
-            draw.rect(game.renderer, rect, 52, 134, 235, 255, true);
+            draw.rect(rect, 52, 134, 235, 255, true);
         }
 
         public static void check_box(int x, int y, ref bool value) {
@@ -99,9 +99,9 @@ namespace Fjord.Modules.Ui
             rect.h = h;
 
             if(value) {
-                draw.rect(game.renderer, rect, 52, 134, 235, 255, true);
+                draw.rect(rect, 52, 134, 235, 255, true);
             } else {
-                draw.rect(game.renderer, rect, 36, 36, 36, 255, true);
+                draw.rect(rect, 36, 36, 36, 255, true);
             }
         }
 
@@ -116,14 +116,14 @@ namespace Fjord.Modules.Ui
             rect.h = h;
 
             if(value) {
-                draw.rect(game.renderer, rect, 52, 134, 235, 255, true);
+                draw.rect(rect, 52, 134, 235, 255, true);
             } else {
-                draw.rect(game.renderer, rect, 36, 36, 36, 255, true);
+                draw.rect(rect, 36, 36, 36, 255, true);
             }
 
             IntPtr tex;
-            font_handler.get_texture(game.renderer, text, font, out tex);
-            draw.texture(game.renderer, tex, x + w / 2, y + h / 2, 0);
+            font_handler.get_texture(text, font, out tex);
+            draw.texture(tex, x + w / 2, y + h / 2, 0);
         }
 
         public static void input_box (int x, int y, int w, int h, string font, ref string value, string default_value, string input_state) {
@@ -160,9 +160,9 @@ namespace Fjord.Modules.Ui
             uint i;
             int j, wi, hi;
             if(value != "") {
-                font_handler.get_texture(game.renderer, value, font, out tex, 0, 0);
+                font_handler.get_texture(value, font, out tex, 0, 0);
             } else {
-                font_handler.get_texture(game.renderer, default_value, font, out tex, 0, 0);
+                font_handler.get_texture(default_value, font, out tex, 0, 0);
             }
             SDL_QueryTexture(tex, out i, out j, out wi, out hi);
 
@@ -173,12 +173,12 @@ namespace Fjord.Modules.Ui
             rect.h = h;
 
             if(input.input_state == input_state) {
-                draw.rect(game.renderer, rect, 52, 134, 235, 255, true);
+                draw.rect(rect, 52, 134, 235, 255, true);
             } else {
-                draw.rect(game.renderer, rect, 36, 36, 36, 255, true);
+                draw.rect(rect, 36, 36, 36, 255, true);
             }
 
-            draw.texture(game.renderer, tex, x + wi / 2 + 5, y + hi / 2 + 2, 0);
+            draw.texture(tex, x + wi / 2 + 5, y + hi / 2 + 2, 0);
         }
 
         public static void text_box (int x, int y, int w, int h, string font, ref string value) {
@@ -186,7 +186,7 @@ namespace Fjord.Modules.Ui
             uint i;
             int j, wi, hi;
             
-            font_handler.get_texture(game.renderer, value, font, out tex, 0, 0);
+            font_handler.get_texture(value, font, out tex, 0, 0);
             
             SDL_QueryTexture(tex, out i, out j, out wi, out hi);
 
@@ -196,7 +196,7 @@ namespace Fjord.Modules.Ui
             rect.w = wi < w ? w : wi + 10;
             rect.h = h;
 
-            draw.texture(game.renderer, tex, x + wi / 2 + 5, y + hi / 2 + 2, 0);
+            draw.texture(tex, x + wi / 2 + 5, y + hi / 2 + 2, 0);
         }
 
         public static void window_movement(ref int x, ref int y, ref int w, ref int h) {


### PR DESCRIPTION
Made 'renderer' default to 'game.renderer' in all cases in the engine as it is always 'game.renderer'.
This is just removing bloat not functionality.
