### PR TITLE
Input State in get any methods

### DIFF
--- a/src/modules/input/input_handler.cs
+++ b/src/modules/input/input_handler.cs
@@ -101,7 +101,7 @@ namespace Fjord.Modules.Input {
         }
 
         public static int get_any_key_pressed(string input_state_check=null) {
-            if(input_state_check != null)
+            if(input_state_check != null && input_state_check != input_state)
                 return -1;
 
             for(var i = 0; i < pressed_keys.Length; i++) {
@@ -113,7 +113,7 @@ namespace Fjord.Modules.Input {
         }
 
         public static int get_any_key_just_pressed(string input_state_check=null) {
-            if(input_state_check != null)
+            if(input_state_check != null && input_state_check != input_state)
                 return -1;
 
             for(var i = 0; i < pressed_keys.Length; i++) {


### PR DESCRIPTION
- Changed keywords from 'static readonly' to 'const' in 'Input'
- Added 'input-state' checks to the get any methods.
- Forgot to add check.
