### PR TITLE
Overload On Add Component Entity

### DIFF
--- a/src/modules/game/entity.cs
+++ b/src/modules/game/entity.cs
@@ -31,6 +31,13 @@ namespace Fjord.Modules.Game
             return this;
         }
 
+        public entity add_component(component Comp) {
+            Comp.parent = this;
+            Comp.on_load();
+            components.Add(Comp);
+            return this;
+        }
+
         public entity remove_component(component Comp) {
             components.Remove(Comp);
             return this;

--- a/src/modules/game/entity.cs
+++ b/src/modules/game/entity.cs
@@ -31,13 +31,6 @@ namespace Fjord.Modules.Game
             return this;
         }
 
-        public entity add_component(component Comp) {
-            Comp.parent = this;
-            Comp.on_load();
-            components.Add(Comp);
-            return this;
-        }
-
         public entity remove_component(component Comp) {
             components.Remove(Comp);
             return this;


### PR DESCRIPTION
- Added overload to 'add_component' in 'entity' to make 'parent' parameter unneeded as it is in almost all circumstaces
- Revert "Added overload to 'add_component' in 'entity' to make 'parent' parameter unneeded as it is in almost all circumstaces"
- Added overload to 'add_component' in 'entity' to make 'parent' parameter unneeded as it is in almost all circumstaces 'all'.
