### PR TITLE
Made 'depth' a global entity variable instead of a 'sprite_renderer' variable as it is used when the entity renders regardless if 'sprite_renderer' is present or not.

### DIFF
--- a/src/modules/game/component.cs
+++ b/src/modules/game/component.cs
@@ -22,7 +22,6 @@ namespace Fjord.Modules.Game {
     public class Sprite_Renderer : component {
         public texture sprite = new texture();
 
-        public int depth = 0;
         public bool visible = true;
 
         public override void update()

--- a/src/modules/game/entity.cs
+++ b/src/modules/game/entity.cs
@@ -11,6 +11,8 @@ namespace Fjord.Modules.Game
     {
         public List<component> components = new List<component>();
 
+        public int depth = 0;
+
         public entity() {
             this.add_component(new Transform());
             this.add_component(new Sprite_Renderer());

--- a/src/modules/game/scene_handler.cs
+++ b/src/modules/game/scene_handler.cs
@@ -12,7 +12,7 @@ namespace Fjord.Modules.Game {
 
         public virtual void update() { foreach(entity e in entities) { e.update(); } }
         public virtual void render() { 
-            List<entity> sorted_entities = entities.OrderBy(e => e.get_component<Sprite_Renderer>().depth).ToList();
+            List<entity> sorted_entities = entities.OrderBy(e => e.depth).ToList();
             foreach(entity e in sorted_entities) { 
                 e.render(); 
             } 


### PR DESCRIPTION
…variable as it is used when the entity renders regardless if 'sprite_renderer' is present or not.