### PR TITLE
Sprite Renderer Relative Camera

### DIFF
--- a/src/modules/game/component.cs
+++ b/src/modules/game/component.cs
@@ -2,6 +2,7 @@ using Fjord.Modules.Mathf;
 using Fjord.Modules.Graphics;
 using static SDL2.SDL;
 using System;
+using Fjord.Modules.Camera;
 
 namespace Fjord.Modules.Game {
     public abstract class component {
@@ -33,7 +34,7 @@ namespace Fjord.Modules.Game {
         public override void render()
         {
             if(visible)
-                draw.texture(parent.get_component<Transform>().position, sprite);
+                draw.texture(parent.get_component<Transform>().position - camera.camera_position, sprite);
         }
     }
 }


### PR DESCRIPTION
- Made the 'tick-fps' function a part of the while loop and made 'MAX_FPS' a mutable int in the 'game_manager' because Fjord was hogging up the gpu when the FPS was uncapped.
- Added camera offset to the 'transform' of the entity to make it relative to the camera.
