### PR TITLE
Fixed 'draw.texture' using the scaled texture size instead of the original texture-size making any scaled texture cut off instead of scaling.

### DIFF
--- a/src/modules/graphics/draw.cs
+++ b/src/modules/graphics/draw.cs
@@ -283,7 +283,7 @@ namespace Fjord.Modules.Graphics {
 
             SDL_Rect src, dest;
 
-            src = new SDL_Rect(0, 0, tex.get_size().x, tex.get_size().y);
+            src = new SDL_Rect(0, 0, tex.get_texture_size().x, tex.get_texture_size().y);
             dest = new SDL_Rect(position.x, position.y, tex.get_size().x, tex.get_size().y);
 
             // Origin Handling

--- a/src/modules/graphics/texture.cs
+++ b/src/modules/graphics/texture.cs
@@ -158,5 +158,14 @@ namespace Fjord.Modules.Graphics {
             texture_size.y = (int)(texture_size.y * scale.y); 
             return texture_size;
         }
+
+        public V2 get_texture_size() {
+            V2 texture_size = new V2();
+            uint format;
+            int access;
+            SDL_QueryTexture(sdl_texture, out format, out access, out texture_size.x, out texture_size.y);
+            
+            return texture_size;
+        }
     }
 }


### PR DESCRIPTION
…ginal texture-size making any scaled texture cut off instead of scaling.